### PR TITLE
fix: install gettext-base to ensure envsubst is available

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -9,6 +9,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install envsubst
+      shell: bash
+      run: |
+        if ! command -v envsubst &> /dev/null; then
+          sudo apt-get update && sudo apt-get install -y gettext-base
+        fi
+
     - name: Set JST time
       shell: bash
       run: echo "JST_TIME=$(TZ=Asia/Tokyo date '+%Y-%m-%dT%H:%M')" >> "$GITHUB_ENV"


### PR DESCRIPTION
GitHub Actions runners may not have envsubst pre-installed.
Add a step to install gettext-base if envsubst is missing.

https://claude.ai/code/session_012yLYq46F4TZKZga2m94o68