### PR TITLE
fix: Radio Free Asia を停止済みとしてソースリストから除外し、The Diplomat に置き換える

### DIFF
--- a/prompts/geopolitics.md
+++ b/prompts/geopolitics.md
@@ -36,7 +36,7 @@
 | 14 | 新華網 | 中国 | 中国語 | http://www.news.cn/rss/politics.xml |
 | 15 | 環球時報 Global Times | 中国 | 英語 | https://www.globaltimes.cn/rss/outbrain.xml |
 | 16 | BBC Chinese | 英国（中国語） | 中国語 | https://feeds.bbci.co.uk/zhongwen/simp/rss.xml |
-| 17 | Radio Free Asia | 米国 | 英語 | https://www.rfa.org/english/rss2.xml |
+| 17 | The Diplomat | 米国（アジア太平洋） | 英語 | https://thediplomat.com/feed/ |
 
 ## 取得失敗時の対応
 


### PR DESCRIPTION
Radio Free Asia は2025年10月に運営停止し、RSSフィードも更新が止まっている。
毎回のレポート実行で無駄なリクエストが発生していたため、
同様のアジア太平洋地政学情報を提供するThe Diplomat に置き換える。

Closes #8

Generated with [Claude Code](https://claude.ai/code)