### PR TITLE
fix: devalue 脆弱性の解消と GitHub Actions の Node 24 対応

### DIFF
--- a/.github/workflows/ai-watch.yml
+++ b/.github/workflows/ai-watch.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/buzz-digest.yml
+++ b/.github/workflows/buzz-digest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -33,7 +33,7 @@ jobs:
       - run: node scripts/validate-reports.mjs --quarantine
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/geopolitics.yml
+++ b/.github/workflows/geopolitics.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/hackernews.yml
+++ b/.github/workflows/hackernews.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/implement-issue.yml
+++ b/.github/workflows/implement-issue.yml
@@ -31,7 +31,7 @@ jobs:
           && !github.event.issue.pull_request)
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
@@ -79,7 +79,7 @@ jobs:
         && github.event_name == 'pull_request_review_comment'
         && contains(github.event.comment.body, '@claude')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/news-briefing.yml
+++ b/.github/workflows/news-briefing.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/tech-feed.yml
+++ b/.github/workflows/tech-feed.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/load-prompt
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {


### PR DESCRIPTION
## 概要

デプロイ復旧後に残っていた2件の警告に対応する。

## 変更内容

### 依存関係の脆弱性（dependabot alert #21, high）
- `devalue` 5.6.4 → 5.8.1（Astro の推移的依存。sparse array デシリアライズによる DoS 脆弱性の修正版）
- `npm audit` で 0 vulnerabilities を確認済み

### GitHub Actions の Node 24 対応
Node 20 ランタイムの action が 2026-06-16 以降 Node 24 強制実行になり、2026-09-16 にランナーから削除されるため、全ワークフローを更新:

| action | before | after |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

### 破壊的変更の確認結果
- **checkout v6**: credential の保存先が git config から別ファイルに変わるのみ。persist 自体は継続するため、レポートエージェントの `git push` に影響なし
- **setup-node v5/v6**: `packageManager` フィールド使用時の自動キャッシュが追加されたが、本リポジトリは未使用のため影響なし
- **upload-pages-artifact v4+**: dotfile がデフォルト除外になるが、Astro の `dist` に dotfile は存在しない（確認済み）

## テスト
- ローカルで `npm run build` 成功（939ページ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)